### PR TITLE
Don't separate "articles" in FAQ

### DIFF
--- a/static/src/faq.tpl.html
+++ b/static/src/faq.tpl.html
@@ -113,8 +113,8 @@
                         <li>
                             <div class="text">
                                 <span class="color gold">Gold tab</span> for <a
-                                    href="https://en.wikipedia.org/wiki/Open_access#Journals:_gold_open_access">Gold OA</a> a
-                                rticles available from the publisher
+                                    href="https://en.wikipedia.org/wiki/Open_access#Journals:_gold_open_access">Gold OA</a> 
+                                articles available from the publisher
                                 under an open license.
                                 <a class="eg" href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0000308">(example)</a>
                             </div>


### PR DESCRIPTION
This currently looks like this:

![article-separated](https://cloud.githubusercontent.com/assets/5199995/23830586/b3d061ee-070e-11e7-9f48-f6eeb2d2e8b8.jpg)

Is it enough to change this in one file or has this also been changed in the [JavaScript files](https://github.com/Impactstory/unpaywall/search?utf8=%E2%9C%93&q=a+rticles)?
