### PR TITLE
use decodeURIComponent rather than decodeURI for gs fulltextLink

### DIFF
--- a/extension/unpaywall.js
+++ b/extension/unpaywall.js
@@ -208,7 +208,7 @@ function checkGsApi(myUrl){
             var plainUrlRegex = /url=(.+?)&hl=/
             var m = plainUrlRegex.exec(fulltextLink.u)
 
-            resolve(decodeURI(m[1]))
+            resolve(decodeURIComponent(m[1]))
         }
 
         }).fail(function(){


### PR DESCRIPTION
Currently the gs cache can be populated with urls that aren't fully decoded. This causes a broken link when clicking through from the browser extension.

GS cache: https://api.oadoi.org/gs/cache/10.1016/j.tetasy.2010.05.004

Gs response here:
https://scholar.google.com/scholar?oi=gsb95&q=http%3A%2F%2Fwww.sciencedirect.com%2Fscience%2Farticle%2Fpii%2FS0957416610003113&output=gsb&hl=en

Original article splash page: http://www.sciencedirect.com/science/article/pii/S0957416610003113