### PR TITLE
Use HTTPS instead of protocol relative URL

### DIFF
--- a/static/src/faq.tpl.html
+++ b/static/src/faq.tpl.html
@@ -16,9 +16,9 @@
 
                     This success rate will improve as we tweak our algorithm and as
                     mandatory open access requirements take effect in the
-                    <a href="http://scholcomm.columbia.edu/open-access/public-access-mandates-for-federally-funded-research/">US,</a>
+                    <a href="https://scholcomm.columbia.edu/open-access/public-access-mandates-for-federally-funded-research/">US,</a>
                     <a href="http://www.rcuk.ac.uk/research/openaccess/">UK,</a>
-                    <a href="http://www.sciencemag.org/news/2016/05/dramatic-statement-european-leaders-call-immediate-open-access-all-scientific-papers/">Europe,</a>
+                    <a href="https://www.sciencemag.org/news/2016/05/dramatic-statement-european-leaders-call-immediate-open-access-all-scientific-papers/">Europe,</a>
                     and elsewhere.
                 </dd>
 

--- a/static/src/footer.tpl.html
+++ b/static/src/footer.tpl.html
@@ -29,7 +29,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="http://twitter.com/unpaywall">
+                    <a href="https://twitter.com/unpaywall">
                         <i class="fa fa-twitter"></i>
                         Twitter
                     </a>
@@ -50,7 +50,7 @@
 
         <div class="credit" flex="25" flex-xs="100">
             <span class="built-by">
-                Built with <i class="fa fa-heart-o"></i> at <a href="http://impactstory.org">Impactstory</a>
+                Built with <i class="fa fa-heart-o"></i> at <a href="https://impactstory.org">Impactstory</a>
 
             </span>
             <span class="funders">

--- a/static/src/sources.tpl.html
+++ b/static/src/sources.tpl.html
@@ -11,7 +11,7 @@
         <div class="header">
             <p>
                 Unpaywall finds OA content in many ways, including using data from open indexes like Crossref and DOAJ where it exists. However, the majority of our OA content comes from independently monitoring over 50,000 unique online content hosting locations, including Gold OA journals, Hybrid journals, institutional repositories, and disciplinary repositories. You can search through our sources below, or
-                <a href="http://api.oadoi.org/data/sources.csv">download the complete sources list.</a>
+                <a href="https://api.oadoi.org/data/sources.csv">download the complete sources list.</a>
             </p>
 
             <p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 
 
     <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/iplffkdpngmdjhlpjmppncnlhomiipha">
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0-rc4/angular-material.min.css">
     <link href="/static/main.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="/static/img/favicon.png" />
@@ -41,7 +41,7 @@
 
 <!-- externally hosted libs outside the Angular ecosystem -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.2/underscore-min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.min.js"></script>
 
 
 <!-- inlined scripts -->


### PR DESCRIPTION
See https://jeremywagner.me/blog/stop-using-the-protocol-relative-url/ for a detailed explanation of why you shoud not use protocol relative URL in 2018.

(I am not sure if this file is still used and where. I was just trying to understand the repo structure when I stumbled on this.)

Feel free to squash my commits if you want.