### PR TITLE
fix handling of urls with anchors

### DIFF
--- a/extension/inside-frame.js
+++ b/extension/inside-frame.js
@@ -4,7 +4,7 @@ if (typeof chrome !== "undefined"){
 
 var parts = window.name.split("#")
 var color = parts[0]
-var url = decodeURI(parts[1])
+var url = decodeURI(parts.slice(1).join('#'))
 
 $(".button")
     .fadeIn()


### PR DESCRIPTION
Motivating example is https://www.biodiversitylibrary.org/item/109652#page/473/mode/1up

The anchor portion gets cut off and the user is sent to the first page of the document.