### PR TITLE
Updated OA colorcode links

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -41,10 +41,10 @@
     </label>
     <p>
         Color-code the unlock tab to show whether fulltext is
-        <a class="green" href="https://en.wikipedia.org/wiki/Open_access#Self-archiving:_green_open_access">Green,</a>
-        <a href="https://en.wikipedia.org/wiki/Open_access#Journals:_gold_open_access" class="gold">Gold,</a>
-        or <a class="bronze" href="10.7287/peerj.preprints.3119v1">Bronze</a> open access, and
-        see expanded debug info. <a href="https://peerj.com/preprints/3119v1/">(learn more about OA colors)</a>
+        <a class="green" href="https://en.wikipedia.org/wiki/Open_access#Green_OA">Green,</a>
+        <a href="https://en.wikipedia.org/wiki/Open_access#Gold_OA" class="gold">Gold,</a>
+        or <a class="bronze" href="https://en.wikipedia.org/wiki/Open_access#Bronze_OA">Bronze</a> open access, and
+        see expanded debug info. <a href="https://peerj.com/articles/4375/">(learn more about OA colors)</a>
     </p>
 </div>
 


### PR DESCRIPTION
The links to Wikipedia descriptions as well as to the peerj arcticle were outdated.

The article is peer reviewed and published now, so the link should go directly there instead of the preprint.